### PR TITLE
fix logout unknown handles when there are no known handles

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,13 +92,12 @@ module.exports = function (logger) {
         }
       })
     }
+  })
 
-    logger.error('\nUnknown handles:\n')
-
-    unknown.forEach(function (stack) {
-      logger.error(stack)
-      logger.error()
-    })
+  logger.error('\nUnknown handles:\n')
+  unknown.forEach(function (stack) {
+    logger.error(stack)
+    logger.error()
   })
 }
 


### PR DESCRIPTION
Currently unknown handles are listed only when an array of known handles has at least one item.
I fixed it so that it also lists unknown handles when there are no known handles.