### PR TITLE
Pass CLI arguments to the program being inspected

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,9 +3,9 @@
 var spawn = require('child_process').spawn
 var path = require('path')
 
-var prog = path.resolve(process.argv[2])
+var prog = process.argv.slice(2)
 
-console.log('probing program', prog)
+console.log('probing program', prog.join(' '))
 
 var nodeArgs = [
   '-r',


### PR DESCRIPTION
Without this, there's no way to pass any command line arguments to the program you want to inspect.