### PR TITLE
Don't report unfulfilled promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var sep = path.sep
 var active = new Map()
 var hook = asyncHooks.createHook({
   init (asyncId, type) {
-    if (type === 'TIMERWRAP') return
+    if (type === 'TIMERWRAP' || type === 'PROMISE') return
     var err = new Error('whatevs')
     var stacks = stackback(err)
     active.set(asyncId, {type, stacks})


### PR DESCRIPTION
Unfulfilled promises don't prevent node from stopping. In my case, the result
was thousands of lines of spurious output, making it impossible to find the one
setTimeout that was causing the problem.