### PR TITLE
Avoid disabling of hook on log

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,8 @@ module.exports = whyIsNodeRunning
 function whyIsNodeRunning (logger) {
   if (!logger) logger = console
 
-  hook.disable()
   logger.error('There are %d handle(s) keeping the process running', active.size)
-  for (const o of active.values()) printStacks(o)
+  for (const o of [...active.values()]) printStacks(o)
 
   function printStacks (o) {
     var stacks = o.stacks.slice(1).filter(function (s) {


### PR DESCRIPTION
This allows a user to log active handlers multiple times during a programs lifetime.

Related to https://github.com/mafintosh/why-is-node-running/issues/42.