### PR TITLE
CLI can pass additional command-line args to child program

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,6 +4,7 @@ var spawn = require('child_process').spawn
 var path = require('path')
 
 var prog = path.resolve(process.argv[2])
+var progArgs = process.argv.slice(3)
 
 console.log('probing program', prog)
 
@@ -12,6 +13,6 @@ var nodeArgs = [
   path.join(__dirname, 'include.js')
 ]
 var nodeOpts = { stdio: 'inherit' }
-var child = spawn('node', nodeArgs.concat(prog), nodeOpts)
+var child = spawn('node', nodeArgs.concat(prog).concat(progArgs), nodeOpts)
 
 console.log('kill -SIGUSR1', child.pid, 'for logging')


### PR DESCRIPTION
This fixes my situation where I want to run `why-is-node-running` around `ts-mocha`:

```
why-is-node-running node_modules/.bin/ts-mocha --paths --watch-extensions ts src/**/*.spec.ts
```

Without this patch `why-is-node-running` invokes `ts-mocha` without any command-line arguments, which is useless to me.

This also still works with no command-line arguments provided beyond the script to run.