### PR TITLE
Fix issue with excluding unrefed timers in node version <v11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ There are 5 handle(s) keeping the process running
 /home/maf/dev/node_modules/why-is-node-running/example.js:13 - setTimeout(function () {
 ```
 
+**Important Note!**
+`unref`ed timers do not prevent the Node process from exiting. If you are running with Node v11.0.0 and above, `unref`ed timers will not be listed in the above list. Unfortunately, this is not supported in node versions below v11.0.0.
+
 ## CLI
 
 You can also run `why-is-node-running` as a standalone if you don't want to include it inside your code. Sending `SIGUSR1` signal to the process will produce the log.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,11 @@ function whyIsNodeRunning (logger) {
 
   hook.disable()
   var activeResources = [...active.values()].filter(function(r) {
-    if (r.type === 'Timeout' && !r.resource.hasRef()) return false
+    if (
+      r.type === 'Timeout' &&
+      typeof r.resource.hasRef === 'function'
+      && !r.resource.hasRef()
+    ) return false
     return true
   })
 


### PR DESCRIPTION
This fixes a critical issue in excluding `unref`ed timers in Node v11.0.0.  `timeout.hasRef()` is only available in Node v11.0.0 and above. This PR adds an additional check for the existence of `hasRef()` to prevent an unhandled error.

cc @mafintosh