### PR TITLE
Correctly detect unref'ed handles

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ function whyIsNodeRunning (logger) {
   hook.disable()
   var activeResources = [...active.values()].filter(function(r) {
     if (
-      r.type === 'Timeout' &&
       typeof r.resource.hasRef === 'function'
       && !r.resource.hasRef()
     ) return false


### PR DESCRIPTION
At this point, `Timeout` objects aren't the only handles that have a
`hasRef()` method. https://github.com/nodejs/node/pull/42756 added
`hasRef()` to the `Worker` handle object that gets reported by `async_hooks`,
so we should consider that too.

Fixes: https://github.com/mafintosh/why-is-node-running/issues/59
Signed-off-by: Darshan Sen <raisinten@gmail.com>