### PR TITLE
Hide internals from modern Node.js versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function whyIsNodeRunning (logger) {
   function printStacks (o) {
     var stacks = o.stacks.slice(1).filter(function (s) {
       var filename = s.getFileName()
-      return filename && filename.indexOf(sep) > -1 && filename.indexOf('internal' + sep) !== 0
+      return filename && filename.indexOf(sep) > -1 && filename.indexOf('internal' + sep) !== 0 && filename.indexOf('node:internal' + sep) !== 0
     })
 
     logger.error('')


### PR DESCRIPTION
Newer versions of Node.js (14 or higher) prefix their internal files with `node:internal` (older version use `internal` without the `node:` prefix). This adds an extra check for newer Node.js versions to ensure internal files of the stack are not printed, for example when running `node ./example.js`:

**Before:**
```log
# Timeout
node:internal/async_hooks:202                                 
node:internal/async_hooks:505                                 
node:internal/timers:160                                      
node:internal/timers:194                                      
/Users/jon/Projects/personal/why-is-node-running/example.js:6  - setInterval(function () {}, 1000)
/Users/jon/Projects/personal/why-is-node-running/example.js:10 - createServer()
node:internal/modules/cjs/loader:1460                         
node:internal/modules/cjs/loader:1544                         

# TCPSERVERWRAP
node:internal/async_hooks:202                                 
/Users/jon/Projects/personal/why-is-node-running/example.js:7  - server.listen(0)
/Users/jon/Projects/personal/why-is-node-running/example.js:10 - createServer()
node:internal/modules/cjs/loader:1460                         
node:internal/modules/cjs/loader:1544                         

# Timeout
node:internal/async_hooks:202                                 
node:internal/async_hooks:505                                 
node:internal/timers:160                                      
node:internal/timers:194                                      
/Users/jon/Projects/personal/why-is-node-running/example.js:6  - setInterval(function () {}, 1000)
/Users/jon/Projects/personal/why-is-node-running/example.js:11 - createServer()
node:internal/modules/cjs/loader:1460                         
node:internal/modules/cjs/loader:1544                         

# TCPSERVERWRAP
node:internal/async_hooks:202                                 
/Users/jon/Projects/personal/why-is-node-running/example.js:7  - server.listen(0)
/Users/jon/Projects/personal/why-is-node-running/example.js:11 - createServer()
node:internal/modules/cjs/loader:1460                         
node:internal/modules/cjs/loader:1544                         

# Timeout
node:internal/async_hooks:202                                 
node:internal/async_hooks:505                                 
node:internal/timers:160                                      
node:internal/timers:194                                      
/Users/jon/Projects/personal/why-is-node-running/example.js:13 - setTimeout(function () {
node:internal/modules/cjs/loader:1460                         
node:internal/modules/cjs/loader:1544                         
node:internal/modules/cjs/loader:1275
```

**After**
```
# Timeout
/Users/jon/Projects/personal/why-is-node-running/example.js:6  - setInterval(function () {}, 1000)
/Users/jon/Projects/personal/why-is-node-running/example.js:10 - createServer()

# TCPSERVERWRAP
/Users/jon/Projects/personal/why-is-node-running/example.js:7  - server.listen(0)
/Users/jon/Projects/personal/why-is-node-running/example.js:10 - createServer()

# Timeout
/Users/jon/Projects/personal/why-is-node-running/example.js:6  - setInterval(function () {}, 1000)
/Users/jon/Projects/personal/why-is-node-running/example.js:11 - createServer()

# TCPSERVERWRAP
/Users/jon/Projects/personal/why-is-node-running/example.js:7  - server.listen(0)
/Users/jon/Projects/personal/why-is-node-running/example.js:11 - createServer()

# Timeout
/Users/jon/Projects/personal/why-is-node-running/example.js:13 - setTimeout(function () {
```