### PR TITLE
Fix typo in `include` entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Node is running but you don't know why? why-is-node-running is here to help you.",
   "exports": {
     ".": "./index.js",
-    "./includes": "./include.js"
+    "./include": "./include.js"
   },
   "dependencies": {
     "siginfo": "^2.0.0",


### PR DESCRIPTION
Fixes a typo in the `include` entrypoint, which was accidentally renamed to `includes`.