### PR TITLE
Add missing permissions to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds the missing permissions that caused the previous [release workflow run](https://github.com/mafintosh/why-is-node-running/actions/runs/9861264188) to fail.