### PR TITLE
Add correct Node.js versions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Node is running but you don't know why? `why-is-node-running` is here to help yo
 
 ## Installation
 
-Node 8 and above:
+Node 20.11 and above (ECMAScript modules):
 
 ```bash
 npm i why-is-node-running -g
 ```
 
-Earlier Node versions (no longer supported):
+Node 8 or higher (CommonJS):
 
 ```bash
-npm i why-is-node-running@v1.x -g
+npm i why-is-node-running@v2.x -g
 ```
 
 ## Usage


### PR DESCRIPTION
Adds the correct Node.js versions for specific versions of `why-is-node-running` to the README, as well as details on supported module systems. This removes all details about v1 from the README as well.