### PR TITLE
Add `files` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     },
     "./include": "./include.js"
   },
+  "files": [
+    "cli.js",
+    "include.js",
+    "index.d.ts",
+    "index.js"
+  ],
   "dependencies": {
     "siginfo": "^2.0.0",
     "stackback": "0.0.2"


### PR DESCRIPTION
Adds the `files` field to the `package.json` to prevent unrelated files from being included in the tarball uploaded to NPM.