### PR TITLE
Remove dependeny on `siginfo` package

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,5 @@ var nodeArgs = [
   path.join(import.meta.dirname, 'include.js')
 ]
 var nodeOpts = { stdio: 'inherit' }
-var child = spawn('node', nodeArgs.concat(prog).concat(progArgs), nodeOpts)
 
-console.log('kill -SIGUSR1', child.pid, 'for logging')
+spawn('node', nodeArgs.concat(prog).concat(progArgs), nodeOpts)

--- a/include.js
+++ b/include.js
@@ -1,4 +1,6 @@
 import whyIsNodeRunning from './index.js'
-import siginfo from 'siginfo'
 
-siginfo(whyIsNodeRunning, true)
+process.on('SIGINFO', () => whyIsNodeRunning())
+process.on('SIGUSR1', () => whyIsNodeRunning())
+
+console.log('kill -SIGUSR1', process.pid, 'for logging')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "siginfo": "^2.0.0",
         "stackback": "0.0.2"
       },
       "bin": {
@@ -18,12 +17,6 @@
       "engines": {
         "node": ">=20.11"
       }
-    },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "license": "ISC"
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "index.js"
   ],
   "dependencies": {
-    "siginfo": "^2.0.0",
     "stackback": "0.0.2"
   },
   "bin": {


### PR DESCRIPTION
Removes the dependency on the `siginfo` package and replace it with direct event listeners. This eliminates some LOC shipped as there is only one code-path. For example, `siginfo` can run without a 'force' mode, and allows for unsubscribing from the events, something that we never do.

This also allows us to possibly address #40 in the future, if we decide to cut a new major at some point.