### PR TITLE
Use relative paths for files under current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,20 @@ Here's the output:
 There are 4 handle(s) keeping the process running
 
 # Timeout
-/path/to/project/example.js:6  - setInterval(() => {}, 1000)
-/path/to/project/example.js:10 - startServer()
+example.js:6  - setInterval(() => {}, 1000)
+example.js:10 - startServer()
 
 # TCPSERVERWRAP
-/path/to/project/example.js:7  - server.listen(0)
-/path/to/project/example.js:10 - startServer()
+example.js:7  - server.listen(0)
+example.js:10 - startServer()
 
 # Timeout
-/path/to/project/example.js:6  - setInterval(() => {}, 1000)
-/path/to/project/example.js:11 - startServer()
+example.js:6  - setInterval(() => {}, 1000)
+example.js:11 - startServer()
 
 # TCPSERVERWRAP
-/path/to/project/example.js:7  - server.listen(0)
-/path/to/project/example.js:11 - startServer()
+example.js:7  - server.listen(0)
+example.js:11 - startServer()
 ```
 
 ## Usage (as a CLI)


### PR DESCRIPTION
Uses relative paths for files under the current working directory, for example:

**Before**
```log
There are 4 handle(s) keeping the process running

# Timeout
/path/to/project/example.js:6  - setInterval(() => {}, 1000)
/path/to/project/example.js:10 - startServer()

# TCPSERVERWRAP
/path/to/project/example.js:7  - server.listen(0)
/path/to/project/example.js:10 - startServer()

# Timeout
/path/to/project/example.js:6  - setInterval(() => {}, 1000)
/path/to/project/example.js:11 - startServer()

# TCPSERVERWRAP
/path/to/project/example.js:7  - server.listen(0)
/path/to/project/example.js:11 - startServer()
```

**After**
```
There are 4 handle(s) keeping the process running

# Timeout
example.js:6  - setInterval(() => {}, 1000)
example.js:10 - startServer()

# TCPSERVERWRAP
example.js:7  - server.listen(0)
example.js:10 - startServer()

# Timeout
example.js:6  - setInterval(() => {}, 1000)
example.js:11 - startServer()

# TCPSERVERWRAP
example.js:7  - server.listen(0)
example.js:11 - startServer()
```

If a path is outside of the current working directory the full absolute path will be used instead.