### PR TITLE
Omit stacks with an untracable file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,10 @@ export default function whyIsNodeRunning (logger = console) {
 }
 
 function printStacks (asyncResource, logger) {
-  const stacks = asyncResource.stacks.filter((stack) => !stack.getFileName().startsWith('node:'))
+  const stacks = asyncResource.stacks.filter((stack) => {
+    const fileName = stack.getFileName()
+    return fileName !== null && !fileName.startsWith('node:')
+  })
 
   logger.error('')
   logger.error(`# ${asyncResource.type}`)


### PR DESCRIPTION
Omits stack traces that cannot be traced back to a specific file from the output.

Closes #81