### PR TITLE
Upgrade publication workflow to Node.js 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Publish to NPM


### PR DESCRIPTION
Upgrades the publication workflow to Node.js 22 since it has [reached LTS status](https://nodejs.org/en/blog/release/v22.11.0).